### PR TITLE
Fix prime number algorithm

### DIFF
--- a/src/common/fx/FeedbackDelayNetwork.cpp
+++ b/src/common/fx/FeedbackDelayNetwork.cpp
@@ -36,7 +36,9 @@ auto generatePrimes(size_t count)
     return true;
   };
 
-  auto i = 2U;
+  primes.push_back(2U);
+
+  auto i = 3U;
   while (primes.size() < count) {
     if (isPrime(i))
       primes.push_back(i);


### PR DESCRIPTION
No primes were being generated since incrementing "2" by two will never yield another prime.

This causes the constructor to loop forever and breaks all plug-ins using the FDN.