### PR TITLE
Remove VST2 builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,9 +40,6 @@ endif()
 
 include(cmake/Dependencies.cmake)
 
-# VST_SDK_PATH is defined in Dependencies.cmake:
-juce_set_vst2_sdk_path(${VST_SDK_PATH})
-
 enable_testing()
 
 find_package(Doxygen)

--- a/cmake/AddPlugin.cmake
+++ b/cmake/AddPlugin.cmake
@@ -38,7 +38,7 @@ function(fsh_add_plugin)
     NEEDS_MIDI_INPUT          ${FSH_IS_SYNTH}
 
     PLUGIN_MANUFACTURER_CODE  Fstk
-    FORMATS                   VST VST3 LV2
+    FORMATS                   VST3 LV2
 
     COMPANY_NAME              fshstk
     COMPANY_WEBSITE           https://docs.fshstk.com

--- a/cmake/Dependencies.cmake
+++ b/cmake/Dependencies.cmake
@@ -32,20 +32,6 @@ FetchContent_Declare(
   GIT_TAG        7.0.9)
 FetchContent_MakeAvailable(JUCE)
 
-# In order to build VST2 plug-ins, we need the VST2 SDK which was removed at some point in Juce 5.
-# Here we grab the last commit before the SDK was removed and make it available via the VST_SDK_PATH
-# variable:
-message(STATUS "Fetching VST2 SDK...")
-FetchContent_Declare(
-  JUCE_VST
-  GIT_REPOSITORY https://github.com/juce-framework/JUCE
-  GIT_TAG        a54535bc317b5c005a8cda5c22a9c8d4c6e0c67e)
-FetchContent_GetProperties(JUCE_VST)
-if(NOT juce_vst_POPULATED)
-  FetchContent_Populate(JUCE_VST)
-endif()
-set(VST_SDK_PATH ${juce_vst_SOURCE_DIR}/modules/juce_audio_processors/format_types/VST3_SDK)
-
 ####################################################################################################
 # FMT - C++ String Formatting
 ####################################################################################################


### PR DESCRIPTION
VST2 is deprecated and may not be distributed without an existing license

(since VST3/LV2 builds are finally working under Linux/Release we can do this now)